### PR TITLE
[codex] Make release publishing retryable

### DIFF
--- a/.changeset/retry-release-publish.md
+++ b/.changeset/retry-release-publish.md
@@ -1,0 +1,7 @@
+---
+'@dle.dev/ember': patch
+---
+
+Make the release script retryable when a release tag already exists but the npm
+version was not published, and publish scoped releases with explicit public
+access.

--- a/.github/scripts/release.mts
+++ b/.github/scripts/release.mts
@@ -47,7 +47,12 @@ function commandSucceeds(cmd: string): boolean {
 try {
 	const raw = await readFile(pkgPath, 'utf8');
 	const pkg = JSON.parse(raw);
+	const packageName = pkg && pkg.name;
 	const version = pkg && pkg.version;
+	if (!packageName) {
+		console.error('package.json does not contain a name field');
+		process.exit(1);
+	}
 	if (!version) {
 		console.error('package.json does not contain a version field');
 		process.exit(1);
@@ -57,30 +62,43 @@ try {
 
 	console.log(`Releasing version ${version}`);
 
+	const packageVersionPublished =
+		!dryRun && commandSucceeds(`npm view ${packageName}@${version} version`);
+	const localTagExists =
+		!dryRun && commandSucceeds(`git rev-parse -q --verify refs/tags/${tag}`);
+	const remoteTagExists =
+		!dryRun &&
+		commandSucceeds(`git ls-remote --exit-code --tags origin refs/tags/${tag}`);
+	const tagExists = localTagExists || remoteTagExists;
+
+	if (packageVersionPublished && tagExists) {
+		console.log(`${packageName}@${version} is already published.`);
+		console.log(`Tag ${tag} already exists; nothing to release.`);
+		process.exit(0);
+	}
+
 	if (!dryRun) {
-		if (commandSucceeds(`git rev-parse -q --verify refs/tags/${tag}`)) {
-			console.error(`Tag ${tag} already exists locally.`);
-			process.exit(1);
+		if (packageVersionPublished) {
+			console.log(`${packageName}@${version} is already published.`);
 		}
 
-		if (
-			commandSucceeds(
-				`git ls-remote --exit-code --tags origin refs/tags/${tag}`
-			)
-		) {
-			console.error(`Tag ${tag} already exists on origin.`);
-			process.exit(1);
+		if (tagExists) {
+			console.log(`Tag ${tag} already exists; skipping tag creation.`);
 		}
 	}
 
-	console.log(`Creating git tag ${tag}`);
-	run(`git tag -a ${tag} -m "${tag}"`);
+	if (!tagExists) {
+		console.log(`Creating git tag ${tag}`);
+		run(`git tag -a ${tag} -m "${tag}"`);
 
-	console.log(`Pushing tag ${tag} to origin`);
-	run(`git push origin ${tag}`);
+		console.log(`Pushing tag ${tag} to origin`);
+		run(`git push origin ${tag}`);
+	}
 
-	console.log('Running: pnpm publish -r');
-	run('pnpm publish -r');
+	if (!packageVersionPublished) {
+		console.log('Running: pnpm publish -r --access public');
+		run('pnpm publish -r --access public');
+	}
 
 	console.log('Release script finished.');
 } catch (err) {


### PR DESCRIPTION
## Summary

Fix the release helper after the 3.2.2 release failed during npm publish.

## Root cause

The release job pushed the `v3.2.2` tag successfully, then npm rejected
`pnpm publish -r` with `E404` for `@dle.dev/ember@3.2.2`. That left GitHub
with a release tag for a version that is not published on npm, and the current
script would reject a rerun because the tag already exists.

## Changes

- Detect whether the package version is already published on npm.
- Detect existing local or remote release tags.
- Treat an existing tag plus unpublished package version as a retryable publish
  path instead of a hard failure.
- Publish with explicit `--access public` for the scoped public package.
- Exit cleanly when both the npm version and release tag already exist.

## Validation

- `DRY_RUN=1 node .github/scripts/release.mts --dry-run`
- `pnpm exec prettier --check .github/scripts/release.mts`
- `pnpm lint`

## Follow-up after merge

Rerun the failed Changeset release workflow for master. Since `v3.2.2` already
exists and `@dle.dev/ember@3.2.2` is not published, the updated script should
skip tag creation and retry npm publish.
