### PR TITLE
Fix npm repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"description": "A headless, accessible, and highly customizable accordion component for Svelte.",
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com:polaroidkidd/ember.git"
+		"url": "git+ssh://git@github.com/polaroidkidd/ember.git"
 	},
 	"bugs": {
 		"url": "https://github.com/polaroidkidd/ember/issues"


### PR DESCRIPTION
## Summary

Normalize the package repository URL to npm's canonical GitHub URL so trusted
publishing can match the package metadata to `polaroidkidd/ember` during the
`3.2.4` publish retry.

### Fixed

- Package repository metadata now matches npm's normalized GitHub URL for
  trusted publishing.
