### PR TITLE
Maintenance: Add Renovate changesets

### DIFF
--- a/.changeset/renovate-changesets.md
+++ b/.changeset/renovate-changesets.md
@@ -1,0 +1,5 @@
+---
+'@dle.dev/ember': patch
+---
+
+Maintenance: Add changesets to Renovate dependency PRs

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
-	"dependencyDashboard": false
+	"dependencyDashboard": false,
+	"postUpgradeTasks": {
+		"commands": ["node scripts/renovate/create-changeset.mjs"],
+		"dataFileTemplate": "{\"title\":\"{{{prTitle}}}\",\"branchName\":\"{{{branchName}}}\",\"upgrades\":[{{#each upgrades}}{\"depName\":\"{{{depName}}}\",\"newVersion\":\"{{{newVersion}}}\",\"updateType\":\"{{{updateType}}}\",\"depType\":\"{{{depType}}}\"}{{#unless @last}},{{/unless}}{{/each}}]}",
+		"fileFilters": [".changeset/*.md"],
+		"executionMode": "branch"
+	}
 }

--- a/scripts/renovate/create-changeset.mjs
+++ b/scripts/renovate/create-changeset.mjs
@@ -1,0 +1,42 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const packageName = '@dle.dev/ember';
+
+function slugifyBranch(branchName) {
+	return branchName
+		.replace(/^renovate\//, '')
+		.replace(/[^a-z0-9]+/gi, '-')
+		.toLowerCase()
+		.replace(/^-|-$/g, '');
+}
+
+export function createChangeset({ dataFile, workspace = process.cwd() }) {
+	if (!dataFile) {
+		throw new Error('Missing RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE');
+	}
+
+	const data = JSON.parse(readFileSync(dataFile, 'utf8'));
+	const slug = slugifyBranch(data.branchName ?? 'dependency-update');
+	const title = data.title ?? 'Maintenance: Update dependencies';
+	const changesetDirectory = join(workspace, '.changeset');
+	const changesetPath = join(changesetDirectory, `renovate-${slug}.md`);
+
+	mkdirSync(changesetDirectory, { recursive: true });
+	writeFileSync(
+		changesetPath,
+		`---
+"${packageName}": patch
+---
+
+${title}
+`
+	);
+}
+
+if (import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+	createChangeset({
+		dataFile: process.env.RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE
+	});
+}

--- a/src/tests/renovate/create-changeset.spec.ts
+++ b/src/tests/renovate/create-changeset.spec.ts
@@ -1,0 +1,50 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { pathToFileURL } from 'url';
+import { describe, expect, test } from 'vitest';
+
+describe('renovate changeset script', () => {
+	test('writes a patch changeset for a Renovate branch', async () => {
+		const workspace = mkdtempSync(join(tmpdir(), 'ember-renovate-'));
+		const dataFile = join(workspace, 'renovate-data.json');
+		const scriptUrl = pathToFileURL(
+			resolve('scripts/renovate/create-changeset.mjs')
+		).href;
+
+		writeFileSync(
+			dataFile,
+			JSON.stringify({
+				branchName: 'renovate/globals-17.x',
+				title: 'Maintenance: Update dependency globals to v17',
+				upgrades: [
+					{
+						depName: 'globals',
+						depType: 'devDependencies',
+						newVersion: '17.6.0',
+						updateType: 'major'
+					}
+				]
+			})
+		);
+
+		const { createChangeset } = await import(scriptUrl);
+
+		createChangeset({
+			dataFile,
+			workspace
+		});
+
+		const changeset = readFileSync(
+			join(workspace, '.changeset', 'renovate-globals-17-x.md'),
+			'utf8'
+		);
+
+		expect(changeset).toBe(`---
+"@dle.dev/ember": patch
+---
+
+Maintenance: Update dependency globals to v17
+`);
+	});
+});


### PR DESCRIPTION
## Summary

Add a Renovate post-upgrade task that writes a patch changeset for dependency update branches, so Renovate PRs include release notes automatically.

### Changed

- Configure Renovate to run `scripts/renovate/create-changeset.mjs` after dependency upgrades.
- Add the Renovate changeset generator and a Vitest spec covering its output.


